### PR TITLE
Fix #45 & #46 Application crash clicking in "About" and max upload file size made configurable

### DIFF
--- a/reqifviewer/Pages/Index/AboutComponent.razor
+++ b/reqifviewer/Pages/Index/AboutComponent.razor
@@ -47,7 +47,7 @@ limitations under the License.
 <div class="row my-4">
     <div class="col-md-12">
         <RadzenCard>
-            <RadzenTextArea Style="height: 300px" Value="@license"></RadzenTextArea>
+            <RadzenTextArea Style="height: 300px; width: 100%;" Value="@license" ReadOnly="true"></RadzenTextArea>
         </RadzenCard>
     </div>
 </div>

--- a/reqifviewer/Program.cs
+++ b/reqifviewer/Program.cs
@@ -74,6 +74,7 @@ namespace reqifviewer
             builder.Services.AddScoped<IReqIFLoaderService, ReqIFLoaderService>();
             builder.Services.AddGoogleAnalytics("295704041");
             builder.Services.AddBlazorStrap();
+            builder.Services.AddHttpClient();
 
             var app = builder.Build();
 

--- a/reqifviewer/Utilities/Constants.cs
+++ b/reqifviewer/Utilities/Constants.cs
@@ -1,0 +1,33 @@
+// -------------------------------------------------------------------------------------------------
+// <copyright file="Constants.cs" company="RHEA System S.A.">
+//
+//   Copyright 2023-2024 RHEA System S.A.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+// </copyright>
+// -------------------------------------------------------------------------------------------------
+
+namespace reqifviewer.Utilities
+{
+    /// <summary>
+    /// Contains constant values that can be shared across the application
+    /// </summary>
+    public static class Constants
+    {
+        /// <summary>
+        /// The name of the configuration key used to retrieve the max upload file size, in megabytes
+        /// </summary>
+        public const string MaxUploadFileSizeInMbConfigurationKey = "MaxUploadFileSizeInMb";
+    }
+}

--- a/reqifviewer/appsettings.Development.json
+++ b/reqifviewer/appsettings.Development.json
@@ -1,0 +1,3 @@
+{
+  "DetailedErrors": true
+}

--- a/reqifviewer/appsettings.json
+++ b/reqifviewer/appsettings.json
@@ -1,4 +1,5 @@
 {
+  "MaxUploadFileSizeInMb": 500,
   "AllowedHosts": "*",
   "Serilog": {
     "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.File" ],


### PR DESCRIPTION
…e upload

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/reqifviewer/pulls) open
- [x] I have verified that I am following the reqifviewer [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/reqifviewer/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Closes #45 When clicking on the about link in the header, the application crashes
Closes #46 The user shall be allowed to upload files larger than 5MB

- HttpClient is now injected
- Max file size upload is now configurable from appsettings.json